### PR TITLE
Document "port" property existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ print(r.scheme) # prom.interface.postgres.Interface
 print(r.username) # testuser
 print(r.password) # testpw
 print(r.host) # localhost
+print(r.port) # 1234
 print(r.hostloc) # localhost:1234
 print(r.paths) # ['testdb']
 ```


### PR DESCRIPTION
From simply reading the docs it isn't obvious that the `.port` property exists and is available for usage, it's only obvious when reading the tests https://github.com/Jaymon/dsnparse/blob/master/dsnparse_test.py#L215

As much as this seems pretty trivial, I've seen this result in developers manually splitting `.hostloc` by `:` which isn't required.