### PR TITLE
Decode url ecnoded characters in username and password

### DIFF
--- a/dsnparse.py
+++ b/dsnparse.py
@@ -113,6 +113,12 @@ class ParseResult(object):
         if hostname is not None:
             hostname = unquote(hostname)
 
+        if username is not None:
+            username = unquote(username)
+
+        if password is not None:
+            password = unquote(password)
+
         options = cls.parse_query(url)
         ret = {
             "dsn": dsn,

--- a/dsnparse_test.py
+++ b/dsnparse_test.py
@@ -244,6 +244,16 @@ class DsnParseTest(TestCase):
         self.assertEqual("/var/lib/postgresql", r.hostname)
         self.assertEqual("dbname", r.database)
 
+    def test_parse_username_with_escaped_characters(self):
+        dsn = "ftp://alice%40example.org:password@hostname"
+        r = dsnparse.parse(dsn)
+        self.assertEqual("alice@example.org", r.username)
+
+    def test_parse_password_with_escaped_characters(self):
+        dsn = "ftp://alice:p%40ssword@hostname"
+        r = dsnparse.parse(dsn)
+        self.assertEqual("p@ssword", r.password)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
As per RFC 1738

```
; URL schemeparts for ip based protocols:

ip-schemepart  = "//" login [ "/" urlpath ]

login          = [ user [ ":" password ] "@" ] hostport
hostport       = host [ ":" port ]
host           = hostname | hostnumber
hostname       = *[ domainlabel "." ] toplabel
domainlabel    = alphadigit | alphadigit *[ alphadigit | "-" ] alphadigit
toplabel       = alpha | alpha *[ alphadigit | "-" ] alphadigit
alphadigit     = alpha | digit
hostnumber     = digits "." digits "." digits "." digits
port           = digits
user           = *[ uchar | ";" | "?" | "&" | "=" ]
password       = *[ uchar | ";" | "?" | "&" | "=" ]
urlpath        = *xchar    ; depends on protocol see [section 3.1](https://datatracker.ietf.org/doc/html/rfc1738#section-3.1) 
```

Where uchar is defined as 

```
reserved       = ";" | "/" | "?" | ":" | "@" | "&" | "="
hex            = digit | "A" | "B" | "C" | "D" | "E" | "F" |
                 "a" | "b" | "c" | "d" | "e" | "f"
escape         = "%" hex hex

unreserved     = alpha | digit | safe | extra
uchar          = unreserved | escape
```

A username or password with special characters ( ";" | "/" | "?" | ":" | "@" | "&" | "=") will have them encoded as the corresponding hex sequence escaped with a "%" character.

Currently urls with this kind of values are returned with escaped characters after parsing instead of showing the raw value. This pull request fixes this issue and adds the corresponding tests.